### PR TITLE
[NAB-375] Variables with no init values referenced in arcs will cause arcs not to load

### DIFF
--- a/src/app/modeler/services/model/model.service.ts
+++ b/src/app/modeler/services/model/model.service.ts
@@ -483,8 +483,10 @@ export class ModelService {
         const referencedData = model.getData(id);
         if (referencedData) {
             if (referencedData.init.value) {
-                return Number(referencedData.init.value);
-                // TODO: NAB-326 check if isFinite and >= 0
+                if (/^[1-9]\d*$/.test(referencedData.init.value.trim())) {
+                    return Number(referencedData.init.value);
+                }
+                return 0;
             }
             return 0;
         }

--- a/src/app/modeler/services/model/model.service.ts
+++ b/src/app/modeler/services/model/model.service.ts
@@ -6,12 +6,13 @@ import {
     DataType,
     DataVariable,
     I18nString,
+    ImportUtils,
     NodeElement,
     PetriNet,
     Place,
     Role,
     Transition,
-    XmlArcType
+    XmlArcType,
 } from '@netgrif/petriflow';
 import {ModelConfig} from './model-config';
 import {CanvasConfiguration} from '@netgrif/petri.svg';
@@ -29,7 +30,7 @@ import {ChangedRole} from '../../role-mode/role-detail/changed-role';
 import {ModelerUtils} from '../../modeler-utils';
 
 @Injectable({
-    providedIn: 'root'
+    providedIn: 'root',
 })
 export class ModelService {
     private readonly _model: BehaviorSubject<PetriNet>;
@@ -59,7 +60,7 @@ export class ModelService {
     ]);
 
     constructor(
-        private arcFactory: ArcFactory
+        private arcFactory: ArcFactory,
     ) {
         this._model = new BehaviorSubject<PetriNet>(undefined);
         this._placeChange = new Subject<PlaceChange>();
@@ -113,7 +114,7 @@ export class ModelService {
             this.alignPositionCoordinate(x, CanvasConfiguration.WIDTH),
             this.alignPositionCoordinate(y, CanvasConfiguration.HEIGHT),
             false,
-            this.nextPlaceId()
+            this.nextPlaceId(),
         );
         if (this.model.getPlaces().length === 0) {
             place.marking = 1;
@@ -177,7 +178,7 @@ export class ModelService {
         const transition = new Transition(
             this.alignPositionCoordinate(x, CanvasConfiguration.WIDTH),
             this.alignPositionCoordinate(y, CanvasConfiguration.HEIGHT),
-            this.nextTransitionId()
+            this.nextTransitionId(),
         );
         this.addTransition(transition);
         return transition;
@@ -272,10 +273,10 @@ export class ModelService {
         return arc;
     }
 
-    public newArcBreakpoint(arc: Arc<NodeElement, NodeElement>, position: DOMPoint, index: number,): void {
+    public newArcBreakpoint(arc: Arc<NodeElement, NodeElement>, position: DOMPoint, index: number): void {
         const breakPoint = new Breakpoint(
             this.alignPositionX(position.x),
-            this.alignPositionY(position.y)
+            this.alignPositionY(position.y),
         );
         arc.breakpoints.splice(index, 0, breakPoint);
         this.model.lastChanged = Date.now();
@@ -455,7 +456,7 @@ export class ModelService {
     public alignPosition(position: DOMPoint): DOMPoint {
         return new DOMPoint(
             this.alignPositionX(position.x),
-            this.alignPositionY(position.y)
+            this.alignPositionY(position.y),
         );
     }
 
@@ -483,7 +484,7 @@ export class ModelService {
         const referencedData = model.getData(id);
         if (referencedData) {
             if (referencedData.init.value) {
-                if (/^[1-9]\d*$/.test(referencedData.init.value.trim())) {
+                if (ImportUtils.isInitValueNumber(referencedData.init)) {
                     return Number(referencedData.init.value);
                 }
                 return 0;
@@ -533,8 +534,8 @@ export class ModelService {
             .map(dg =>
                 dg.getDataRefs()
                     .map(ref =>
-                        ModelerUtils.numberOfEventActions(ref.getEvents())
-                    ).reduce((sum, current) => sum + current, 0)
+                        ModelerUtils.numberOfEventActions(ref.getEvents()),
+                    ).reduce((sum, current) => sum + current, 0),
             ).reduce((sum, current) => sum + current, 0);
         return eventActions + dataRefActions;
     }

--- a/src/app/modeler/simulation-mode/simulation-mode.service.ts
+++ b/src/app/modeler/simulation-mode/simulation-mode.service.ts
@@ -87,7 +87,13 @@ export class SimulationModeService extends CanvasModeService<SimulationTool> {
         this.originalModel = new BehaviorSubject<PetriNet>(this.modelService.model.clone());
         this.originalModel.subscribe(model => {
             this.data = new Map(model.getArcs().filter(a => !!a.reference && !!model.getData(a.reference))
-                .map(a => [a.reference, Number.parseInt(model.getData(a.reference).init?.value, 10) || 0]));
+                .map(a => {
+                    const data = model.getData(a.reference);
+                    if (!!data.init && !!data.init.value && /^[1-9]\d*$/.test(data.init.value)) {
+                        return [a.reference, Number.parseInt(data.init.value, 10)];
+                    }
+                    return [a.reference, 0];
+                }));
             this.simulation = new BasicSimulation(model, this.data);
             this.renderModel(model);
         });

--- a/src/app/modeler/simulation-mode/simulation-mode.service.ts
+++ b/src/app/modeler/simulation-mode/simulation-mode.service.ts
@@ -1,6 +1,6 @@
 import {Injectable, Injector} from '@angular/core';
 import {BehaviorSubject} from 'rxjs';
-import {Arc, BasicSimulation, PetriNet, Place, Transition} from '@netgrif/petriflow';
+import {Arc, BasicSimulation, ImportUtils, PetriNet, Place, Transition} from '@netgrif/petriflow';
 import {TutorialService} from '../../tutorial/tutorial-service';
 import {ModelService} from '../services/model/model.service';
 import {EventSimulationTool} from './tool/event-simulation.tool';
@@ -24,7 +24,7 @@ import {SimulationMode} from './simulation-mode';
 import {CanvasPlace} from '../edit-mode/domain/canvas-place';
 
 @Injectable({
-    providedIn: 'root'
+    providedIn: 'root',
 })
 export class SimulationModeService extends CanvasModeService<SimulationTool> {
 
@@ -74,7 +74,7 @@ export class SimulationModeService extends CanvasModeService<SimulationTool> {
             new ChangeDataTool(modelService, dialog, this, router, transitionService),
             new ResetPositionAndZoomTool(modelService, dialog, this, router, transitionService),
             new GridTool(modelService, dialog, this, router, transitionService),
-            new SwitchLabelTool(modelService, dialog, this, router, transitionService)
+            new SwitchLabelTool(modelService, dialog, this, router, transitionService),
         );
         this.switchTools.tools.forEach(t => t.bind());
         this.tools = [
@@ -82,14 +82,14 @@ export class SimulationModeService extends CanvasModeService<SimulationTool> {
                 this.defaultTool,
                 new EventSimulationTool(modelService, dialog, this, router, transitionService),
             ),
-            this.switchTools
+            this.switchTools,
         ];
         this.originalModel = new BehaviorSubject<PetriNet>(this.modelService.model.clone());
         this.originalModel.subscribe(model => {
             this.data = new Map(model.getArcs().filter(a => !!a.reference && !!model.getData(a.reference))
                 .map(a => {
                     const data = model.getData(a.reference);
-                    if (!!data.init && !!data.init.value && /^[1-9]\d*$/.test(data.init.value)) {
+                    if (ImportUtils.isInitValueNumber(data.init)) {
                         return [a.reference, Number.parseInt(data.init.value, 10)];
                     }
                     return [a.reference, 0];


### PR DESCRIPTION
# Description

Arcs which referenced data has non positive integer value will be displayed/represented with value 0 in edit + simulation mode

Fixes [NAB-375] 

## Dependencies

No new dependencies were introduced

### Third party dependencies

No new dependencies were introduced

### Blocking Pull requests

Blocking by [PF-79]

## How Has Been This Tested?

Manually tested in local dev env in running application

| Name                | Tested on |
|---------------------| --------- |
| OS                  |     Linux Mint 21      |
| Runtime             |      Node 20.13.1      |
| Dependency Manager  |    npm  10.8.0    |
| Framework version   |    Angular 13.3.1       |
| Run parameters      |           |
| Other configuration |           |


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes have been checked, personally or remotely, with @...
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have resolved all conflicts with the target branch of the PR
- [x] I have updated and synced my code with the target branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes:
    - [x] Lint test
    - [x] Unit tests
    - [x] Integration tests
- [ ] I have checked my contribution with code analysis tools:
    - [ ] [SonarCloud](https://sonarcloud.io/project/overview?id=netgrif_application-builder)
    - [ ] [Snyk](https://app.snyk.io/org/netgrif)
- [x] I have made corresponding changes to the documentation:
    - [x] Developer documentation
    - [x] User Guides


[NAB-375]: https://netgrif.atlassian.net/browse/NAB-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PF-79]: https://netgrif.atlassian.net/browse/PF-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ